### PR TITLE
Adiciona meta de viewport responsiva

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 
 <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
     <title>Quotes</title>
     <link rel="stylesheet" href="mystyle.css">
     <script type="text/javascript" src="quotes.js"></script>


### PR DESCRIPTION
A meta HTML de viewport controla:

- O tamanho da página
- O zoom inicial da página

Nesse caso, o `width=device-width`, então se você tem uma tela de 500px, e faz que o width de algo é 50%, o elemento vai ter 250px. O `initial-scale=1` faz com que o zoom da página inicie como 1 no browser. Em especial, nos browsers em celulares, que tem DPI muito alto:


> On high dpi screens, pages with initial-scale=1 will effectively be zoomed by browsers. Their text will be smooth and crisp, but their bitmap images will probably not take advantage of the full screen resolution. To get sharper images on these screens, web developers may want to design images – or whole layouts – at a higher scale than their final size and then scale them down using CSS or viewport properties. This is consistent with the CSS 2.1 specification, which says:

> If the pixel density of the output device is very different from that of a typical computer display, the user agent should rescale pixel values. It is recommended that the pixel unit refer to the whole number of device pixels that best approximates the reference pixel. It is recommended that the reference pixel be the visual angle of one pixel on a device with a pixel density of 96dpi and a distance from the reader of an arm's length.


Fonte: https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag

Essa metatag já é o suficiente para que a página fique responsiva. Print:

![image](https://user-images.githubusercontent.com/14908759/109237535-7d981380-77b0-11eb-8e2a-ba4fd8cb6e64.png)
