### PR TITLE
Mudança de Tooltips para idioma Português.

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
       </blockquote>
     </div>
     <div class="flex-button">
-      <button title="new quote" class="btn-rotate" id="newQuote">&#8635;</button>
+      <button title="nova inspiração" class="btn-rotate" id="newQuote">&#8635;</button>
     </div>
     <div class="flex-button">
-      <button title="settings" class="btn" id="settings">&#9881;</button>
+      <button title="configuração" class="btn" id="settings">&#9881;</button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
Notei que havia colocado os Tooltips dos botões em Inglês e o idioma default da página é Portuguê.
Este PR retifica o meu erro.